### PR TITLE
Add hotp command based off of totp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LDLIBS=-L../mbedtls-2.3.0/library/ -lmbedcrypto -ldl
 
 PLYMOUTH_LDLIBS = `pkg-config --libs ply-boot-client`
 
-APPS=qrenc totp base32
+APPS=qrenc totp hotp base32
 
 all: $(APPS) extra
 
@@ -37,6 +37,7 @@ libtpm/libtpm.a:
 
 unsealtotp: unsealtotp.o oath.o
 totp: totp.o oath.o
+hotp: hotp.o oath.o
 base32: base32-main.o base32.o
 
 plymouth-unsealtotp: plymouth-unsealtotp.c

--- a/hotp.c
+++ b/hotp.c
@@ -1,0 +1,53 @@
+/*
+ * Read a secret from stdin and generate the HOTP hash based on the time.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <time.h>
+#include "oath.h"
+#include <stdlib.h>
+
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2)
+  {
+		fprintf(stderr, "Usage: %s <counter>\n", argv[0]);
+    return -1;
+  }
+
+	const size_t keylen = 20;
+	unsigned char key[keylen];
+  uint32_t increment = atoi(argv[1]);
+
+	// this will fail on partial reads, unlikely
+	ssize_t rc = read(0, key, sizeof(key));
+
+	if (rc < 0)
+	{
+		perror("stdin");
+		return -1;
+	}
+
+	if (rc != (ssize_t) keylen)
+	{
+		fprintf(stderr, "Expected %zu bytes, read %zu\n",
+			keylen,
+			rc
+		);
+		return -1;
+	}
+
+	uint32_t token = hotp_calc(increment, key, keylen);
+
+  printf("%06d\n", token);
+
+	return 0;
+}

--- a/oath.c
+++ b/oath.c
@@ -216,3 +216,38 @@ oauth_calc(
 
 	return truncatedHash;
 }
+/** C function to do hotp computation */
+uint32_t
+hotp_calc(
+	uint32_t counter,
+	const uint8_t * secret,
+	size_t secret_len
+)
+{
+	uint8_t byteArray[] = {
+		0,
+		0,
+		0,
+		0,
+		counter >> 24,
+		counter >> 16,
+		counter >>  8,
+		counter >>  0,
+	};
+
+	sha1_initHmac(secret, secret_len);
+	sha1_writebytes(byteArray, 8);
+	const uint8_t * const hash = sha1_resultHmac();
+  
+	const unsigned offset = hash[20 - 1] & 0xF; 
+	uint32_t truncatedHash = 0;
+	for (int j = 0; j < 4; ++j) {
+		truncatedHash <<= 8;
+		truncatedHash  |= hash[offset + j];
+	}
+    
+	truncatedHash &= 0x7FFFFFFF;
+	truncatedHash %= 1000000;
+
+	return truncatedHash;
+}

--- a/oath.h
+++ b/oath.h
@@ -10,6 +10,12 @@ oauth_calc(
 	const uint8_t * secret,
 	size_t secret_len
 );
+extern uint32_t
+hotp_calc(
+	uint32_t counter,
+	const uint8_t * secret,
+	size_t secret_len
+);
 
 
 #endif


### PR DESCRIPTION
I would like to add HOTP support to Heads/tpmtotp in addition to TOTP so
Heads can authenticate to devices without a clock while using the same
secret stored in the TPM.